### PR TITLE
Add ERC-7730 descriptor for tether/root

### DIFF
--- a/registry/tether/root.json
+++ b/registry/tether/root.json
@@ -1,0 +1,774 @@
+{
+  "$schema": null,
+  "context": {
+    "$id": "a",
+    "contract": {
+      "deployments": [
+        {
+          "chainId": 56,
+          "address": "0x55d398326f99059ff775485246999027b3197955"
+        },
+        {
+          "chainId": 1,
+          "address": "0xdac17f958d2ee523a2206206994597c13d831ec7"
+        }
+      ],
+      "abi": [
+        {
+          "type": "function",
+          "name": "_decimals",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint8",
+              "internalType": "uint8",
+              "components": null,
+              "indexed": null,
+              "unit": null
+            }
+          ],
+          "stateMutability": "view",
+          "constant": true,
+          "payable": false,
+          "gas": null,
+          "signature": null
+        },
+        {
+          "type": "function",
+          "name": "_name",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "string",
+              "internalType": "string",
+              "components": null,
+              "indexed": null,
+              "unit": null
+            }
+          ],
+          "stateMutability": "view",
+          "constant": true,
+          "payable": false,
+          "gas": null,
+          "signature": null
+        },
+        {
+          "type": "function",
+          "name": "_symbol",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "string",
+              "internalType": "string",
+              "components": null,
+              "indexed": null,
+              "unit": null
+            }
+          ],
+          "stateMutability": "view",
+          "constant": true,
+          "payable": false,
+          "gas": null,
+          "signature": null
+        },
+        {
+          "type": "function",
+          "name": "allowance",
+          "inputs": [
+            {
+              "name": "owner",
+              "type": "address",
+              "internalType": "address",
+              "components": null,
+              "indexed": null,
+              "unit": null
+            },
+            {
+              "name": "spender",
+              "type": "address",
+              "internalType": "address",
+              "components": null,
+              "indexed": null,
+              "unit": null
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256",
+              "internalType": "uint256",
+              "components": null,
+              "indexed": null,
+              "unit": null
+            }
+          ],
+          "stateMutability": "view",
+          "constant": true,
+          "payable": false,
+          "gas": null,
+          "signature": null
+        },
+        {
+          "type": "function",
+          "name": "approve",
+          "inputs": [
+            {
+              "name": "spender",
+              "type": "address",
+              "internalType": "address",
+              "components": null,
+              "indexed": null,
+              "unit": null
+            },
+            {
+              "name": "amount",
+              "type": "uint256",
+              "internalType": "uint256",
+              "components": null,
+              "indexed": null,
+              "unit": null
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool",
+              "internalType": "bool",
+              "components": null,
+              "indexed": null,
+              "unit": null
+            }
+          ],
+          "stateMutability": "nonpayable",
+          "constant": false,
+          "payable": false,
+          "gas": null,
+          "signature": null
+        },
+        {
+          "type": "function",
+          "name": "balanceOf",
+          "inputs": [
+            {
+              "name": "account",
+              "type": "address",
+              "internalType": "address",
+              "components": null,
+              "indexed": null,
+              "unit": null
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256",
+              "internalType": "uint256",
+              "components": null,
+              "indexed": null,
+              "unit": null
+            }
+          ],
+          "stateMutability": "view",
+          "constant": true,
+          "payable": false,
+          "gas": null,
+          "signature": null
+        },
+        {
+          "type": "function",
+          "name": "burn",
+          "inputs": [
+            {
+              "name": "amount",
+              "type": "uint256",
+              "internalType": "uint256",
+              "components": null,
+              "indexed": null,
+              "unit": null
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool",
+              "internalType": "bool",
+              "components": null,
+              "indexed": null,
+              "unit": null
+            }
+          ],
+          "stateMutability": "nonpayable",
+          "constant": false,
+          "payable": false,
+          "gas": null,
+          "signature": null
+        },
+        {
+          "type": "function",
+          "name": "decimals",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint8",
+              "internalType": "uint8",
+              "components": null,
+              "indexed": null,
+              "unit": null
+            }
+          ],
+          "stateMutability": "view",
+          "constant": true,
+          "payable": false,
+          "gas": null,
+          "signature": null
+        },
+        {
+          "type": "function",
+          "name": "decreaseAllowance",
+          "inputs": [
+            {
+              "name": "spender",
+              "type": "address",
+              "internalType": "address",
+              "components": null,
+              "indexed": null,
+              "unit": null
+            },
+            {
+              "name": "subtractedValue",
+              "type": "uint256",
+              "internalType": "uint256",
+              "components": null,
+              "indexed": null,
+              "unit": null
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool",
+              "internalType": "bool",
+              "components": null,
+              "indexed": null,
+              "unit": null
+            }
+          ],
+          "stateMutability": "nonpayable",
+          "constant": false,
+          "payable": false,
+          "gas": null,
+          "signature": null
+        },
+        {
+          "type": "function",
+          "name": "getOwner",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "address",
+              "components": null,
+              "indexed": null,
+              "unit": null
+            }
+          ],
+          "stateMutability": "view",
+          "constant": true,
+          "payable": false,
+          "gas": null,
+          "signature": null
+        },
+        {
+          "type": "function",
+          "name": "increaseAllowance",
+          "inputs": [
+            {
+              "name": "spender",
+              "type": "address",
+              "internalType": "address",
+              "components": null,
+              "indexed": null,
+              "unit": null
+            },
+            {
+              "name": "addedValue",
+              "type": "uint256",
+              "internalType": "uint256",
+              "components": null,
+              "indexed": null,
+              "unit": null
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool",
+              "internalType": "bool",
+              "components": null,
+              "indexed": null,
+              "unit": null
+            }
+          ],
+          "stateMutability": "nonpayable",
+          "constant": false,
+          "payable": false,
+          "gas": null,
+          "signature": null
+        },
+        {
+          "type": "function",
+          "name": "mint",
+          "inputs": [
+            {
+              "name": "amount",
+              "type": "uint256",
+              "internalType": "uint256",
+              "components": null,
+              "indexed": null,
+              "unit": null
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool",
+              "internalType": "bool",
+              "components": null,
+              "indexed": null,
+              "unit": null
+            }
+          ],
+          "stateMutability": "nonpayable",
+          "constant": false,
+          "payable": false,
+          "gas": null,
+          "signature": null
+        },
+        {
+          "type": "function",
+          "name": "name",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "string",
+              "internalType": "string",
+              "components": null,
+              "indexed": null,
+              "unit": null
+            }
+          ],
+          "stateMutability": "view",
+          "constant": true,
+          "payable": false,
+          "gas": null,
+          "signature": null
+        },
+        {
+          "type": "function",
+          "name": "owner",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "address",
+              "internalType": "address",
+              "components": null,
+              "indexed": null,
+              "unit": null
+            }
+          ],
+          "stateMutability": "view",
+          "constant": true,
+          "payable": false,
+          "gas": null,
+          "signature": null
+        },
+        {
+          "type": "function",
+          "name": "renounceOwnership",
+          "inputs": [],
+          "outputs": [],
+          "stateMutability": "nonpayable",
+          "constant": false,
+          "payable": false,
+          "gas": null,
+          "signature": null
+        },
+        {
+          "type": "function",
+          "name": "symbol",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "string",
+              "internalType": "string",
+              "components": null,
+              "indexed": null,
+              "unit": null
+            }
+          ],
+          "stateMutability": "view",
+          "constant": true,
+          "payable": false,
+          "gas": null,
+          "signature": null
+        },
+        {
+          "type": "function",
+          "name": "totalSupply",
+          "inputs": [],
+          "outputs": [
+            {
+              "name": "",
+              "type": "uint256",
+              "internalType": "uint256",
+              "components": null,
+              "indexed": null,
+              "unit": null
+            }
+          ],
+          "stateMutability": "view",
+          "constant": true,
+          "payable": false,
+          "gas": null,
+          "signature": null
+        },
+        {
+          "type": "function",
+          "name": "transfer",
+          "inputs": [
+            {
+              "name": "recipient",
+              "type": "address",
+              "internalType": "address",
+              "components": null,
+              "indexed": null,
+              "unit": null
+            },
+            {
+              "name": "amount",
+              "type": "uint256",
+              "internalType": "uint256",
+              "components": null,
+              "indexed": null,
+              "unit": null
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool",
+              "internalType": "bool",
+              "components": null,
+              "indexed": null,
+              "unit": null
+            }
+          ],
+          "stateMutability": "nonpayable",
+          "constant": false,
+          "payable": false,
+          "gas": null,
+          "signature": null
+        },
+        {
+          "type": "function",
+          "name": "transferFrom",
+          "inputs": [
+            {
+              "name": "sender",
+              "type": "address",
+              "internalType": "address",
+              "components": null,
+              "indexed": null,
+              "unit": null
+            },
+            {
+              "name": "recipient",
+              "type": "address",
+              "internalType": "address",
+              "components": null,
+              "indexed": null,
+              "unit": null
+            },
+            {
+              "name": "amount",
+              "type": "uint256",
+              "internalType": "uint256",
+              "components": null,
+              "indexed": null,
+              "unit": null
+            }
+          ],
+          "outputs": [
+            {
+              "name": "",
+              "type": "bool",
+              "internalType": "bool",
+              "components": null,
+              "indexed": null,
+              "unit": null
+            }
+          ],
+          "stateMutability": "nonpayable",
+          "constant": false,
+          "payable": false,
+          "gas": null,
+          "signature": null
+        },
+        {
+          "type": "function",
+          "name": "transferOwnership",
+          "inputs": [
+            {
+              "name": "newOwner",
+              "type": "address",
+              "internalType": "address",
+              "components": null,
+              "indexed": null,
+              "unit": null
+            }
+          ],
+          "outputs": [],
+          "stateMutability": "nonpayable",
+          "constant": false,
+          "payable": false,
+          "gas": null,
+          "signature": null
+        }
+      ],
+      "addressMatcher": null,
+      "factory": null
+    }
+  },
+  "metadata": {
+    "owner": "a",
+    "info": {
+      "legalName": "a",
+      "url": "a"
+    }
+  },
+  "display": {
+    "formats": {
+      "deprecate(address)": {
+        "$id": null,
+        "intent": "a",
+        "screens": null,
+        "fields": [
+          {
+            "$id": null,
+            "label": "Upgraded Address",
+            "format": "addressName",
+            "params": {
+              "types": [
+                "wallet",
+                "eoa",
+                "contract",
+                "token",
+                "collection"
+              ],
+              "sources": null
+            },
+            "path": "#._upgradedAddress",
+            "value": null
+          }
+        ],
+        "required": [
+          "#._upgradedAddress"
+        ],
+        "excluded": null
+      },
+      "approve(address,uint256)": {
+        "$id": null,
+        "intent": "a",
+        "screens": null,
+        "fields": [
+          {
+            "$id": null,
+            "label": "Spender",
+            "format": "addressName",
+            "params": {
+              "types": [
+                "contract"
+              ],
+              "sources": null
+            },
+            "path": "#._spender",
+            "value": null
+          },
+          {
+            "$id": null,
+            "label": "Value",
+            "format": "amount",
+            "params": null,
+            "path": "#._value",
+            "value": null
+          }
+        ],
+        "required": [
+          "#._spender",
+          "#._value"
+        ],
+        "excluded": null
+      },
+      "mintToken(uint256,uint256,address,uint256,bytes)": {
+        "$id": null,
+        "intent": "z",
+        "screens": null,
+        "fields": [
+          {
+            "$id": null,
+            "label": "Event Id",
+            "format": "raw",
+            "params": null,
+            "path": "#.eventId",
+            "value": null
+          },
+          {
+            "$id": null,
+            "label": "Token Id",
+            "format": "raw",
+            "params": null,
+            "path": "#.tokenId",
+            "value": null
+          },
+          {
+            "$id": null,
+            "label": "Receiver",
+            "format": "addressName",
+            "params": {
+              "types": [
+                "eoa",
+                "wallet"
+              ],
+              "sources": null
+            },
+            "path": "#.receiver",
+            "value": null
+          },
+          {
+            "$id": null,
+            "label": "Expiration Time",
+            "format": "date",
+            "params": {
+              "encoding": "timestamp"
+            },
+            "path": "#.expirationTime",
+            "value": null
+          },
+          {
+            "$id": null,
+            "label": "Signature",
+            "format": "raw",
+            "params": null,
+            "path": "#.signature",
+            "value": null
+          }
+        ],
+        "required": [
+          "#.eventId",
+          "#.tokenId",
+          "#.receiver",
+          "#.expirationTime",
+          "#.signature"
+        ],
+        "excluded": null
+      },
+      "setFeeReceiver(address)": {
+        "$id": null,
+        "intent": "z",
+        "screens": null,
+        "fields": [
+          {
+            "$id": null,
+            "label": "Fee Receiver",
+            "format": "addressName",
+            "params": {
+              "types": [
+                "eoa",
+                "wallet"
+              ],
+              "sources": null
+            },
+            "path": "#._feeReceiver",
+            "value": null
+          }
+        ],
+        "required": [
+          "#._feeReceiver"
+        ],
+        "excluded": null
+      },
+      "transferProxyOwnership(address)": {
+        "$id": null,
+        "intent": "a",
+        "screens": null,
+        "fields": [
+          {
+            "$id": null,
+            "label": "New Owner",
+            "format": "addressName",
+            "params": {
+              "types": [
+                "eoa",
+                "wallet"
+              ],
+              "sources": null
+            },
+            "path": "#.newOwner",
+            "value": null
+          }
+        ],
+        "required": [
+          "#.newOwner"
+        ],
+        "excluded": null
+      },
+      "allowance(address,address)": {
+        "$id": null,
+        "intent": "a",
+        "screens": null,
+        "fields": [
+          {
+            "$id": null,
+            "label": "Owner",
+            "format": "addressName",
+            "params": {
+              "types": [
+                "eoa",
+                "wallet"
+              ],
+              "sources": null
+            },
+            "path": "#.owner",
+            "value": null
+          },
+          {
+            "$id": null,
+            "label": "Spender",
+            "format": "addressName",
+            "params": {
+              "types": [
+                "contract"
+              ],
+              "sources": null
+            },
+            "path": "#.spender",
+            "value": null
+          }
+        ],
+        "required": [
+          "#.owner",
+          "#.spender"
+        ],
+        "excluded": null
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR adds an ERC-7730 descriptor for the tether protocol.

## Summary
- **Protocol**: tether
- **Contract**: root
- **Contract Address**: `0x55d398326f99059ff775485246999027b3197955`
- **File Path**: `registry/tether/root.json`
- **Generated via**: [Clear Signing ERC7730 Builder](https://clear-signing-erc7730-builder.vercel.app/)

Please review the descriptor for accuracy and completeness.